### PR TITLE
feat: enable react compiler

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   typedRoutes: true,
+  reactCompiler: true,
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request makes a small configuration change to the Next.js project. The change enables the React Compiler by setting the `reactCompiler` option to `true` in the `next.config.ts` file.

Closes #20 